### PR TITLE
Make linkedItems optional

### DIFF
--- a/src/Kentico/Kontent/Delivery/DefaultMapper.php
+++ b/src/Kentico/Kontent/Delivery/DefaultMapper.php
@@ -180,7 +180,7 @@ class DefaultMapper implements TypeMapperInterface, PropertyMapperInterface, Val
      * 
      * @return string
      */
-    public function resolveInlineLinkedItems($input, $item, $linkedItems)
+    public function resolveInlineLinkedItems($input, $item, $linkedItems = null)
     {
         if(isset($item) && strpos($input, $item->system->codename) !== false){
             return $input;

--- a/src/Kentico/Kontent/Delivery/InlineLinkedItemsResolverInterface.php
+++ b/src/Kentico/Kontent/Delivery/InlineLinkedItemsResolverInterface.php
@@ -19,5 +19,5 @@ interface InlineLinkedItemsResolverInterface
      * 
      * @return string
      */
-    public function resolveInlineLinkedItems($input, $item, $linkedItems);
+    public function resolveInlineLinkedItems($input, $item, $linkedItems = null);
 }


### PR DESCRIPTION
### Motivation

Relates to #106.

Changes in #106 lead to a breaking change. Adding a parameter to the interface is a breaking change - to prevent this, it should be OK to make it optional.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
