### PR TITLE
PHP 8 support

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -2,7 +2,7 @@ name: Build & Test & Report
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:        
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:        
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:        
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4']
         phpunit-versions: ['latest']
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:        
-        php-versions: ['7.0', '7.1', '7.2', '7.3']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
         phpunit-versions: ['latest']
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpdocumentor/phpdocumentor": "2.*",
         "codeclimate/php-test-reporter": "dev-master",
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^8.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "phpdocumentor/shim": "^3.3",
-        "phpunit/phpunit": "^8.5.12"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,17 @@
         "kub-at/php-simple-html-dom-parser": "^1.9"
     },
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "2.*",
-        "codeclimate/php-test-reporter": "dev-master",
+        "phpdocumentor/shim": "^3.3",
         "phpunit/phpunit": "^8.5.12"
     },
     "autoload": {
         "psr-4": {
             "Kentico\\Kontent\\": "src/Kentico/Kontent"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpdocumentor/shim": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "nategood/httpful": "^0.2.20",
         "kub-at/php-simple-html-dom-parser": "^1.9"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
-        <testsuite name="e2e">
-            <directory>tests/E2E</directory>
-        </testsuite>
-        <testsuite name="official">
-            <directory>tests/Official</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+    <testsuite name="e2e">
+      <directory>tests/E2E</directory>
+    </testsuite>
+    <testsuite name="official">
+      <directory>tests/Official</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/tests/E2E/DeliveryClientTest.php
+++ b/tests/E2E/DeliveryClientTest.php
@@ -32,8 +32,8 @@ class DeliveryClientTest extends TestCase
         $this->assertEquals('coffee-processing-techniques', $item->urlPattern);
         $this->assertInstanceOf(\Kentico\Kontent\Delivery\Models\Items\ContentItemSystem::class, $item->system);
         $this->assertInstanceOf(\Kentico\Kontent\Delivery\Models\Items\ContentItemSystem::class, $item->system);
-        $this->assertContains('<a data-item-id="80c7074b-3da1-4e1d-882b-c5716ebb4d25" href="/kenya-gakuyuni-aa">Kenya Gakuyuni AA</a>', $item->bodyCopy);
-        $this->assertContains('<a data-item-id="0c9a11bb-6fc3-409c-b3cb-f0b797e15489" href="/brazil-natural-barra-grande">Brazil Natural Barra Grande</a>', $item->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="80c7074b-3da1-4e1d-882b-c5716ebb4d25" href="/kenya-gakuyuni-aa">Kenya Gakuyuni AA</a>', $item->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="0c9a11bb-6fc3-409c-b3cb-f0b797e15489" href="/brazil-natural-barra-grande">Brazil Natural Barra Grande</a>', $item->bodyCopy);
     }
 
     public function testGetHomeItem()
@@ -71,7 +71,7 @@ class DeliveryClientTest extends TestCase
     {
         $client = new DeliveryClient($this->getProjectId());
         $item = $client->getItem('brazil_natural_barra_grande');
-        $this->assertInternalType('float', $item->price);
+        $this->assertIsFloat($item->price);
         $this->assertEquals(8.5, $item->price);
     }
 

--- a/tests/E2E/DeliveryClientTest.php
+++ b/tests/E2E/DeliveryClientTest.php
@@ -43,7 +43,7 @@ class DeliveryClientTest extends TestCase
         $this->assertEquals('1bd6ba00-4bf2-4a2b-8334-917faa686f66', $item->system->id);
         $this->assertInstanceOf(\DateTime::class, $item->system->getLastModifiedDateTime());
         $this->assertInstanceOf(\DateTime::class, $item->system->lastModified);
-        $this->assertRegExp('/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/', $item->system->getLastModifiedDateTime('Y-m-d'));
+        $this->assertMatchesRegularExpression('/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/', $item->system->getLastModifiedDateTime('Y-m-d'));
     }
 
     public function testGetNonExistentItem()

--- a/tests/E2E/ModelBindingTest.php
+++ b/tests/E2E/ModelBindingTest.php
@@ -52,8 +52,8 @@ class ModelBindingTest extends TestCase
         $this->assertEquals('117cdfae-52cf-4885-b271-66aef6825612', $item->system->id);
         $this->assertEquals('Coffee processing techniques', $item->title);
         $this->assertEquals('coffee-processing-techniques', $item->urlPattern);
-        $this->assertContains('<a data-item-id="80c7074b-3da1-4e1d-882b-c5716ebb4d25" href="/custom/kenya-gakuyuni-aa">Kenya Gakuyuni AA</a>', $item->bodyCopy);
-        $this->assertContains('<a data-item-id="0c9a11bb-6fc3-409c-b3cb-f0b797e15489" href="/custom/brazil-natural-barra-grande">Brazil Natural Barra Grande</a>', $item->bodyCopy);        
+        $this->assertStringContainsString('<a data-item-id="80c7074b-3da1-4e1d-882b-c5716ebb4d25" href="/custom/kenya-gakuyuni-aa">Kenya Gakuyuni AA</a>', $item->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="0c9a11bb-6fc3-409c-b3cb-f0b797e15489" href="/custom/brazil-natural-barra-grande">Brazil Natural Barra Grande</a>', $item->bodyCopy);
     }
 
     public function testHomeModel()

--- a/tests/Official/CodeExampleTest.php
+++ b/tests/Official/CodeExampleTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class CodeExamplesTests extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = new DeliveryClient('975bf280-fd91-488c-994c-2f04416e5ee3');
     }
@@ -33,7 +33,7 @@ class CodeExamplesTests extends TestCase
         
         $this->assertNotNull($items);
         $this->assertNotNull($items->items);
-        $this->assertInternalType('array', $items->items);        
+        $this->assertIsArray($items->items);
     }
 
     public function test_OneType()
@@ -49,7 +49,7 @@ class CodeExamplesTests extends TestCase
 
         $this->assertNotNull($types);  
         $this->assertNotNull($types->types);
-        $this->assertInternalType('array', $types->types);  
+        $this->assertIsArray($types->types);
     }
 
     public function test_contentTypeElement()
@@ -66,7 +66,7 @@ class CodeExamplesTests extends TestCase
 
         $this->assertNotNull($taxonomies);  
         $this->assertNotNull($taxonomies->taxonomies);
-        $this->assertInternalType('array', $taxonomies->taxonomies);  
+        $this->assertIsArray($taxonomies->taxonomies);
     }
 
     public function test_getFiveLatestArticles()
@@ -79,7 +79,7 @@ class CodeExamplesTests extends TestCase
         
         $this->assertNotNull($items);
         $this->assertNotNull($items->items);
-        $this->assertInternalType('array', $items->items); 
+        $this->assertIsArray($items->items);
     }
 
     public function test_getArticlesWithTaxonomyTerm()
@@ -89,7 +89,7 @@ class CodeExamplesTests extends TestCase
         
         $this->assertNotNull($items);
         $this->assertNotNull($items->items);
-        $this->assertInternalType('array', $items->items); 
+        $this->assertIsArray($items->items);
     }
 
     public function test_getContentInSpecificLanguageWithFallback()

--- a/tests/Unit/ModelBinderTest.php
+++ b/tests/Unit/ModelBinderTest.php
@@ -33,11 +33,11 @@ class ModelBinderTest extends TestCase
         $model = $modelBinder->bindModel(\Kentico\Kontent\Delivery\Models\Items\ContentItem::class, $data);
 
         // Test content links
-        $this->assertContains('<a data-item-id="00000000-0000-0000-0000-000000000002" href="/custom/link-1">Link 1</a>', $model->bodyCopy);
-        $this->assertContains('<a data-item-id="00000000-0000-0000-0000-000000000003" href="/custom/link-2">Link 2</a>', $model->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="00000000-0000-0000-0000-000000000002" href="/custom/link-1">Link 1</a>', $model->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="00000000-0000-0000-0000-000000000003" href="/custom/link-2">Link 2</a>', $model->bodyCopy);
 
         // Test broken links
-        $this->assertContains('<a data-item-id="FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF" href="/404">404</a>', $model->bodyCopy);
+        $this->assertStringContainsString('<a data-item-id="FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF" href="/404">404</a>', $model->bodyCopy);
     }
 
     public function test_BindModel_DefaultImplementation_InlineLinkedItemsNotChanged()
@@ -53,8 +53,8 @@ class ModelBinderTest extends TestCase
 
         $model = $modelBinder->bindModel(\Kentico\Kontent\Delivery\Models\Items\ContentItem::class, $data->item, $data->modular_content);
 
-        $this->assertContains('<object type="application/kenticocloud" data-type="item" data-codename="modular_item_1"></object>', $model->bodyCopy);
-        $this->assertContains('<object type="application/kenticocloud" data-type="item" data-codename="modular_item_2"></object>', $model->bodyCopy);
+        $this->assertStringContainsString('<object type="application/kenticocloud" data-type="item" data-codename="modular_item_1"></object>', $model->bodyCopy);
+        $this->assertStringContainsString('<object type="application/kenticocloud" data-type="item" data-codename="modular_item_2"></object>', $model->bodyCopy);
     }
 
     public function test_BindModel_DefaultImplementationEmptyRichTextValue_ResolvedWithNoError()
@@ -95,10 +95,10 @@ class ModelBinderTest extends TestCase
 
         $model = $modelBinder->bindModel(\Kentico\Kontent\Delivery\Models\Items\ContentItem::class, $data->item, $data->modular_content);
 
-        $this->assertContains('<div>Modular item 1</div>', $model->bodyCopy);
-        $this->assertContains('<div>Modular item 2</div>', $model->bodyCopy);
-        $this->assertContains('<object type="application/kenticocloud" data-type="noitem" data-codename="modular_item_1"></object>', $model->bodyCopy);
-        $this->assertContains('<object type="text/xml" data-type="item" data-codename="modular_item_1"></object>', $model->bodyCopy);
+        $this->assertStringContainsString('<div>Modular item 1</div>', $model->bodyCopy);
+        $this->assertStringContainsString('<div>Modular item 2</div>', $model->bodyCopy);
+        $this->assertStringContainsString('<object type="application/kenticocloud" data-type="noitem" data-codename="modular_item_1"></object>', $model->bodyCopy);
+        $this->assertStringContainsString('<object type="text/xml" data-type="item" data-codename="modular_item_1"></object>', $model->bodyCopy);
     }
 
     public function test_BindModel_MockImplementation_TableInRichTextResolved()

--- a/tests/Unit/UrlBuilderTest.php
+++ b/tests/Unit/UrlBuilderTest.php
@@ -68,29 +68,29 @@ class UrlBuilderTest extends TestCase
 
         $url = $builder->getItemsUrl($params);
 
-        $this->assertContains('skip=2', $url);
-        $this->assertContains('order=title%5Basc%5D', $url);
+        $this->assertStringContainsString('skip=2', $url);
+        $this->assertStringContainsString('order=title%5Basc%5D', $url);
 
-        $this->assertContains('elements.personas%5Ball%5D=barista%2Ccoffee_blogger', $url);
-        $this->assertContains('elements.description%5Bany%5D=Hello', $url);
-        $this->assertContains('elements.title%5Bcontains%5D=a', $url);
-        $this->assertContains('elements.margin%5Bin%5D=21%2C15%2C19', $url);
-        $this->assertContains('elements.oldMargin%5Bnin%5D=42%2C666', $url);
+        $this->assertStringContainsString('elements.personas%5Ball%5D=barista%2Ccoffee_blogger', $url);
+        $this->assertStringContainsString('elements.description%5Bany%5D=Hello', $url);
+        $this->assertStringContainsString('elements.title%5Bcontains%5D=a', $url);
+        $this->assertStringContainsString('elements.margin%5Bin%5D=21%2C15%2C19', $url);
+        $this->assertStringContainsString('elements.oldMargin%5Bnin%5D=42%2C666', $url);
 
-        $this->assertContains('elements.isfeatured=true', $url);
-        $this->assertContains('system.type%5Bneq%5D=article', $url);
+        $this->assertStringContainsString('elements.isfeatured=true', $url);
+        $this->assertStringContainsString('system.type%5Bneq%5D=article', $url);
 
-        $this->assertContains('elements.note%5Bempty%5D', $url);
-        $this->assertContains('elements.slug%5Bnempty%5D', $url);
+        $this->assertStringContainsString('elements.note%5Bempty%5D', $url);
+        $this->assertStringContainsString('elements.slug%5Bnempty%5D', $url);
 
-        $this->assertContains('system.collection=default', $url);
-        $this->assertContains('elements.price%5Bgt%5D=6', $url);
-        $this->assertContains('elements.oldprice%5Bgte%5D=7', $url);
-        $this->assertContains('elements.shoesize%5Brange%5D=7%2C9', $url);
-        $this->assertContains('elements.tax%5Blt%5D=21', $url);
-        $this->assertContains('elements.oldtax%5Blte%5D=25', $url);
+        $this->assertStringContainsString('system.collection=default', $url);
+        $this->assertStringContainsString('elements.price%5Bgt%5D=6', $url);
+        $this->assertStringContainsString('elements.oldprice%5Bgte%5D=7', $url);
+        $this->assertStringContainsString('elements.shoesize%5Brange%5D=7%2C9', $url);
+        $this->assertStringContainsString('elements.tax%5Blt%5D=21', $url);
+        $this->assertStringContainsString('elements.oldtax%5Blte%5D=25', $url);
 
-        $this->assertContains('includeTotalCount=1', $url);
+        $this->assertStringContainsString('includeTotalCount=1', $url);
     }
 
     public function testGetTaxonomy()


### PR DESCRIPTION
Fixes #111 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] ~Automated tests have been added~ (no code in `src` was changed)
- [x] Tests are passing
- [ ] ~Docs have been updated (if applicable)~ (support is stated as "PHP 7 and above", which covers PHP 8 too)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

API reference can be generated by running `vendor/bin/phpdoc`
